### PR TITLE
feat: phase 4 - config api and configurator tendril

### DIFF
--- a/cmd/stem/cmd-serve.go
+++ b/cmd/stem/cmd-serve.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/opentendril/core/cmd/stem/internal/api"
+	"github.com/opentendril/core/cmd/stem/internal/configurator"
 	"github.com/opentendril/core/cmd/stem/internal/orchestrator"
 	"github.com/opentendril/core/cmd/stem/internal/security"
 )
@@ -38,8 +40,13 @@ type Choice struct {
 func runServeCmd(ctx context.Context, args []string) {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("POST /v1/chat/completions", handleChatCompletions)
+	mux.HandleFunc("/v1/chat/completions", handleChatCompletions)
 	mux.HandleFunc("GET /health", handleHealth)
+
+	// Phase 4: Configuration API
+	tendrilDir := "./.tendril"
+	configHandler := api.NewConfigHandler(tendrilDir)
+	configHandler.SetupRoutes(mux)
 
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -100,15 +107,28 @@ func handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("Spawning Tendril for task: %s", taskPrompt)
 
-	// Phase 3: Execute the Python Tendril via the Orchestrator
-	engine := orchestrator.NewDockerOrchestrator()
-	output, err := engine.RunTendril(r.Context(), taskPrompt)
+	var output string
+	var err error
+
+	// Route to internal Configurator Tendril or external Docker Tendril
+	if req.Model == "configurator" {
+		configTendril := configurator.NewConfiguratorTendril(triggersDir)
+		output, err = configTendril.Execute(r.Context(), taskPrompt)
+	} else {
+		// Phase 3: Execute the Python Tendril via the Orchestrator
+		orch := &orchestrator.DockerOrchestrator{
+			ImageName: "core-tendril:latest", // Hardcoded for now
+		}
+		output, err = orch.RunTendril(r.Context(), taskPrompt)
+	}
+
 	if err != nil {
 		log.Printf("Tendril execution failed: %v", err)
-		http.Error(w, "Tendril execution failed", http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
+	// Format response as OpenAI completion
 	resp := ChatCompletionResponse{
 		ID:      "chatcmpl-tendril",
 		Object:  "chat.completion",

--- a/cmd/stem/internal/api/config.go
+++ b/cmd/stem/internal/api/config.go
@@ -1,0 +1,225 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// AuthMiddleware wraps a handler to require an ADMIN_TOKEN.
+func AuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token := os.Getenv("ADMIN_TOKEN")
+		if token != "" {
+			authHeader := r.Header.Get("Authorization")
+			if !strings.HasPrefix(authHeader, "Bearer ") || strings.TrimPrefix(authHeader, "Bearer ") != token {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+		next(w, r)
+	}
+}
+
+// ConfigHandler provides HTTP endpoints for managing .tendril configs
+type ConfigHandler struct {
+	TendrilDir string
+}
+
+func NewConfigHandler(tendrilDir string) *ConfigHandler {
+	return &ConfigHandler{TendrilDir: tendrilDir}
+}
+
+type Trigger struct {
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+}
+
+// ListTriggers handles GET /v1/config/triggers
+func (h *ConfigHandler) ListTriggers(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	triggersDir := filepath.Join(h.TendrilDir, "transduction", "hormonal-triggers")
+	entries, err := os.ReadDir(triggersDir)
+	if err != nil && !os.IsNotExist(err) {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var triggers []Trigger
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			info, _ := entry.Info()
+			triggers = append(triggers, Trigger{
+				Name: entry.Name(),
+				Size: info.Size(),
+			})
+		}
+	}
+
+	if triggers == nil {
+		triggers = []Trigger{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"triggers": triggers,
+	})
+}
+
+// UploadTrigger handles POST /v1/config/triggers
+func (h *ConfigHandler) UploadTrigger(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// 10 MB max memory for parsing multipart form
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		http.Error(w, "Failed to parse form", http.StatusBadRequest)
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, "Missing file part", http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	if strings.Contains(header.Filename, "/") || strings.Contains(header.Filename, "\\") {
+		http.Error(w, "Invalid filename", http.StatusBadRequest)
+		return
+	}
+
+	triggersDir := filepath.Join(h.TendrilDir, "transduction", "hormonal-triggers")
+	os.MkdirAll(triggersDir, 0755)
+
+	targetPath := filepath.Join(triggersDir, header.Filename)
+	out, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755) // Ensure executable
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to create file: %v", err), http.StatusInternalServerError)
+		return
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, file); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to save file: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Uploaded new Hormonal Trigger: %s", header.Filename)
+	w.WriteHeader(http.StatusCreated)
+	w.Write([]byte("Trigger uploaded successfully.\n"))
+}
+
+// ListPersonas handles GET /v1/config/personas
+func (h *ConfigHandler) ListPersonas(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	personasDir := filepath.Join(h.TendrilDir, "personas")
+	entries, err := os.ReadDir(personasDir)
+	if err != nil && !os.IsNotExist(err) {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var personas []string
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+			personas = append(personas, strings.TrimSuffix(entry.Name(), ".json"))
+		}
+	}
+
+	if personas == nil {
+		personas = []string{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"personas": personas,
+	})
+}
+
+// UploadPersona handles POST /v1/config/personas
+func (h *ConfigHandler) UploadPersona(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var payload map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "Invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	nameObj, ok := payload["name"]
+	if !ok {
+		http.Error(w, "Missing 'name' field", http.StatusBadRequest)
+		return
+	}
+	name, ok := nameObj.(string)
+	if !ok || name == "" {
+		http.Error(w, "Invalid 'name' field", http.StatusBadRequest)
+		return
+	}
+
+	personasDir := filepath.Join(h.TendrilDir, "personas")
+	os.MkdirAll(personasDir, 0755)
+
+	targetPath := filepath.Join(personasDir, name+".json")
+	out, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to create file: %v", err), http.StatusInternalServerError)
+		return
+	}
+	defer out.Close()
+
+	if err := json.NewEncoder(out).Encode(payload); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to write config: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Uploaded new AI Persona: %s", name)
+	w.WriteHeader(http.StatusCreated)
+	w.Write([]byte("Persona saved successfully.\n"))
+}
+
+// SetupRoutes registers the configuration endpoints
+func (h *ConfigHandler) SetupRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/config/triggers", func(w http.ResponseWriter, r *http.Request) {
+		AuthMiddleware(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				h.ListTriggers(w, r)
+			} else if r.Method == http.MethodPost {
+				h.UploadTrigger(w, r)
+			} else {
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			}
+		})(w, r)
+	})
+
+	mux.HandleFunc("/v1/config/personas", func(w http.ResponseWriter, r *http.Request) {
+		AuthMiddleware(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				h.ListPersonas(w, r)
+			} else if r.Method == http.MethodPost {
+				h.UploadPersona(w, r)
+			} else {
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			}
+		})(w, r)
+	})
+}

--- a/cmd/stem/internal/configurator/tendril.go
+++ b/cmd/stem/internal/configurator/tendril.go
@@ -1,0 +1,94 @@
+package configurator
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// ConfiguratorTendril handles the generation of .tendril configurations
+// using an LLM to interpret user requests.
+type ConfiguratorTendril struct {
+	TriggersDir string
+	client      *openai.Client
+}
+
+func NewConfiguratorTendril(triggersDir string) *ConfiguratorTendril {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	client := openai.NewClient(apiKey)
+	return &ConfiguratorTendril{
+		TriggersDir: triggersDir,
+		client:      client,
+	}
+}
+
+// Execute processes a user task aimed at configuration management
+func (c *ConfiguratorTendril) Execute(ctx context.Context, taskPrompt string) (string, error) {
+	log.Printf("Spawning Configurator Tendril for task: %s", taskPrompt)
+
+	systemPrompt := `You are the OpenTendril Configurator Tendril.
+Your job is to generate bash scripts for 'Hormonal Triggers' to secure the system.
+A Hormonal Trigger is an executable script placed in '.tendril/transduction/hormonal-triggers/'.
+It receives a JSON payload path as $1 containing {"persona": "...", "task": "..."}.
+If the trigger exits with > 0, the task is blocked. If 0, it is allowed.
+
+Respond ONLY with the raw bash script code. Do not use markdown blocks like ` + "```bash" + ` or ` + "```" + `.
+Do not include any explanations. Only output the script.`
+
+	req := openai.ChatCompletionRequest{
+		Model: openai.GPT4o,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleSystem,
+				Content: systemPrompt,
+			},
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: taskPrompt,
+			},
+		},
+	}
+
+	resp, err := c.client.CreateChatCompletion(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("Configurator failed to generate script: %w", err)
+	}
+
+	scriptContent := strings.TrimSpace(resp.Choices[0].Message.Content)
+	scriptContent = strings.TrimPrefix(scriptContent, "```bash")
+	scriptContent = strings.TrimPrefix(scriptContent, "```")
+	scriptContent = strings.TrimSuffix(scriptContent, "```")
+	scriptContent = strings.TrimSpace(scriptContent)
+
+	if !strings.HasPrefix(scriptContent, "#!") {
+		scriptContent = "#!/bin/bash\n\n" + scriptContent
+	}
+
+	// Determine a slug for the filename based on the prompt or just use a generic one
+	filename := "trigger-generated.sh"
+	if strings.Contains(strings.ToLower(taskPrompt), "block") {
+		filename = "block-trigger.sh"
+	}
+	
+	os.MkdirAll(c.TriggersDir, 0755)
+
+	targetPath := filepath.Join(c.TriggersDir, filename)
+	
+	// Create file as executable
+	out, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return "", fmt.Errorf("Failed to write trigger file %s: %w", filename, err)
+	}
+	defer out.Close()
+
+	if _, err := out.WriteString(scriptContent); err != nil {
+		return "", fmt.Errorf("Failed to write script content: %w", err)
+	}
+
+	return fmt.Sprintf("✅ Configurator Tendril successfully generated and saved '%s' to '%s'.", filename, c.TriggersDir), nil
+}

--- a/cmd/stem/main.go
+++ b/cmd/stem/main.go
@@ -12,9 +12,14 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/joho/godotenv"
 )
 
 func main() {
+	// Load .env file if it exists
+	_ = godotenv.Load()
+
 	if len(os.Args) < 2 {
 		printUsage()
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,8 @@ module github.com/opentendril/core
 go 1.24.0
 
 require github.com/gorilla/websocket v1.5.3
+
+require (
+	github.com/joho/godotenv v1.5.1 // indirect
+	github.com/sashabaranov/go-openai v1.41.2 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/sashabaranov/go-openai v1.41.2 h1:vfPRBZNMpnqu8ELsclWcAvF19lDNgh1t6TVfFFOPiSM=
+github.com/sashabaranov/go-openai v1.41.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=


### PR DESCRIPTION
This PR implements Phase 4 of the Go Stem Architecture migration, focusing on the `.tendril` Configuration API and the Configurator Tendril.

### Changes:
1. **Configuration APIs**: Implemented `GET` and `POST` endpoints on the Go Stem under `/v1/config/triggers` and `/v1/config/personas` to expose management capabilities.
2. **Authentication**: Secured the management endpoints with an `ADMIN_TOKEN` Bearer auth middleware.
3. **Configurator Tendril**: Added `cmd/stem/internal/configurator/tendril.go` to act as a native Go-based AI agent that generates bash scripts via the OpenAI API and automatically installs them into the Hormonal Triggers directory when requested.