### PR TITLE
feat: phase 5 - local-first onboarding with Ollama support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,13 @@ tendril-node-*.pub
 # CLI build artifacts
 cli/dist/
 cli/tendril-cli
+
+# Go Stem build artifacts
+cmd/stem/stem
+cmd/stem/tendril
+cmd/stem/tendril-cli
+cmd/stem/server.log
+
+# Generated .tendril runtime files (user-local, not committed)
+.tendril/transduction/hormonal-triggers/block-trigger.sh
+.tendril/transduction/hormonal-triggers/*-generated.sh

--- a/cmd/stem/cmd-chat.go
+++ b/cmd/stem/cmd-chat.go
@@ -97,7 +97,8 @@ func sendHTTP(base *url.URL, msg string) (string, error) {
 	u := *base
 	u.Path = "/v1/chat/completions"
 	reqBody := ChatRequest{
-		Model: "gpt-4", // Default model; can be configured later
+		// Use model name from env, default to "local" so Go Stem routes correctly
+		Model: getEnvOrDefaultStr("LOCAL_MODEL_NAME", os.Getenv("DEFAULT_LLM_PROVIDER")),
 		Messages: []Message{
 			{Role: "user", Content: msg},
 		},
@@ -170,12 +171,13 @@ func runChatCmd(ctx context.Context, args []string) {
 		}
 	}
 
-	base, err := url.Parse("http://localhost:9090") // default URL
+	base, err := url.Parse("http://localhost:8080") // Go Stem default port
 	if err != nil {
 		log.Fatal("Invalid URL:", err)
 	}
 
-	// Ensure the backend is running before connecting
+	// Check Go Stem is reachable
+	fmt.Println("🌱 Connecting to OpenTendril Stem...")
 	ensureBackendOnline(ctx, "http://localhost:8080")
 
 	sendFunc, err := connect(base, useWS)
@@ -183,7 +185,7 @@ func runChatCmd(ctx context.Context, args []string) {
 		log.Fatal("Failed to connect:", err)
 	}
 
-	log.Println("Tendril CLI connected! Type 'exit' or Ctrl+C to quit.")
+	log.Println("Connected! Type your task below, or 'exit' to quit.")
 	log.Println("Tip: Use 'tendril chat --http' to force HTTP mode.")
 
 	scanner := bufio.NewScanner(os.Stdin)
@@ -240,4 +242,14 @@ func runChatCmd(ctx context.Context, args []string) {
 	if err := scanner.Err(); err != nil {
 		log.Printf("Scanner error: %v", err)
 	}
+}
+
+func getEnvOrDefaultStr(key, fallback string) string {
+	if val := os.Getenv(key); val != "" {
+		return val
+	}
+	if fallback != "" {
+		return fallback
+	}
+	return "local" // final fallback for the Go Stem router
 }

--- a/cmd/stem/cmd-init.go
+++ b/cmd/stem/cmd-init.go
@@ -27,19 +27,33 @@ func runInitCmd(args []string) {
 	inferenceURL := ""
 
 	if len(ollamaModels) > 0 {
-		fmt.Printf("✅ Detected local Ollama instance with %d models.\n", len(ollamaModels))
-		fmt.Println("Would you like to use Ollama for local execution? (y/n)")
+		fmt.Printf("✅ Detected local Ollama with %d model(s):\n", len(ollamaModels))
+		for i, m := range ollamaModels {
+			fmt.Printf("  %d) %s\n", i+1, m)
+		}
+		fmt.Println("Would you like to use Ollama for local, private execution? (y/n)")
 		fmt.Print("> ")
 		if scanner.Scan() {
 			ans := strings.ToLower(strings.TrimSpace(scanner.Text()))
 			if ans == "y" || ans == "yes" {
 				defaultProvider = "local"
-				inferenceURL = "http://localhost:11434/v1"
+				// Use host.docker.internal so the Docker Tendril container can reach Ollama on the host
+				inferenceURL = "http://host.docker.internal:11434/v1"
 				localModel = selectOllamaModel(ollamaModels)
+				// Let user override model choice
+				fmt.Printf("Auto-selected model: %s\n", localModel)
+				fmt.Printf("Press Enter to use it, or type a different model name: ")
+				if scanner.Scan() {
+					if override := strings.TrimSpace(scanner.Text()); override != "" {
+						localModel = override
+					}
+				}
+				fmt.Printf("✅ Using Ollama model: %s\n", localModel)
 			}
 		}
 	} else {
-		fmt.Println("❌ No local Ollama instance detected.")
+		fmt.Println("ℹ️  No local Ollama instance detected at localhost:11434.")
+		fmt.Println("   Start Ollama with: ollama serve")
 	}
 
 	// If they didn't choose local, let's ask about cloud
@@ -125,20 +139,29 @@ func runInitCmd(args []string) {
 		fmt.Printf("✅ Saved to %s\n", envPath)
 	}
 
-	// Step 3: Print MCP integration guide
-	fmt.Println("\n🔌 MCP Integration Guide")
-	fmt.Println("To connect Antigravity (or Claude Desktop) to OpenTendril, add the following to your MCP configuration file:")
-	fmt.Println("For Antigravity, edit: ~/.gemini/config/mcp_config.json")
-	fmt.Println("\n{")
-	fmt.Println(`  "mcpServers": {`)
-	fmt.Println(`    "opentendril": {`)
-	fmt.Printf(`      "command": "%s",`+"\n", filepath.Join(homeDir, ".local", "bin", "tendril"))
-	fmt.Println(`      "args": ["mcp"],`)
-	fmt.Println(`      "env": {}`)
-	fmt.Println(`    }`)
-	fmt.Println(`  }`)
-	fmt.Println("}")
-	fmt.Println("\n🎉 Setup Complete! You can now run `tendril chat` to start coding, or restart your IDE to enable the MCP connection.")
+	// Step 3: Print next steps
+	homeBin := filepath.Join(homeDir, ".local", "bin", "tendril")
+	fmt.Println()
+	fmt.Println("════════════════════════════════════════")
+	fmt.Println("  🎉 OpenTendril Setup Complete!")
+	fmt.Println("════════════════════════════════════════")
+	if defaultProvider == "local" {
+		fmt.Printf("  Provider : Ollama (local, private)\n")
+		fmt.Printf("  Model    : %s\n", localModel)
+		fmt.Printf("  URL      : %s\n", inferenceURL)
+	} else {
+		fmt.Printf("  Provider : %s\n", defaultProvider)
+	}
+	fmt.Println()
+	fmt.Println("  Next steps:")
+	fmt.Println("  1. Start the Stem server:   tendril serve")
+	fmt.Println("  2. Chat in a new terminal:  tendril chat")
+	fmt.Println()
+	fmt.Println("  MCP Integration (for Antigravity / Claude Desktop):")
+	fmt.Println("  Edit: ~/.gemini/config/mcp_config.json")
+	fmt.Println("  Add:")
+	fmt.Printf("    {\"mcpServers\": {\"opentendril\": {\"command\": \"%s\", \"args\": [\"mcp\"]}}}\n", homeBin)
+	fmt.Println("════════════════════════════════════════")
 }
 
 func getOllamaModels() []string {

--- a/cmd/stem/internal/orchestrator/docker.go
+++ b/cmd/stem/internal/orchestrator/docker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // DockerOrchestrator implements the Orchestrator interface using the local Docker daemon.
@@ -19,25 +20,67 @@ func NewDockerOrchestrator() *DockerOrchestrator {
 }
 
 func (d *DockerOrchestrator) RunTendril(ctx context.Context, taskPrompt string) (string, error) {
-	cmd := exec.CommandContext(ctx, "docker", "run", "--rm",
+	// Build the docker run arguments
+	args := []string{
+		"run", "--rm",
 		"--network", "core_default",
+		// Allow the container to reach Ollama running on the host
+		"--add-host=host.docker.internal:host-gateway",
 		"--env-file", ".env",
 		"--entrypoint", "python",
 		"-e", fmt.Sprintf("TASK_PROMPT=%s", taskPrompt),
-		"-e", fmt.Sprintf("OPENAI_API_KEY=%s", os.Getenv("OPENAI_API_KEY")),
-		"-e", "POSTGRES_USER=postgres",
-		"-e", "POSTGRES_PASSWORD=tendril_default_db_secret",
-		"-e", "REDIS_PASSWORD=tendril_default_redis_secret",
-		"-v", fmt.Sprintf("%s:/app", os.Getenv("PWD")),
+		// Inject credentials from host environment
+		"-e", fmt.Sprintf("REDIS_PASSWORD=%s", getEnvOrDefault("REDIS_PASSWORD", "tendril_default_redis_secret")),
+		"-e", fmt.Sprintf("POSTGRES_USER=%s", getEnvOrDefault("POSTGRES_USER", "postgres")),
+		"-e", fmt.Sprintf("POSTGRES_PASSWORD=%s", getEnvOrDefault("POSTGRES_PASSWORD", "tendril_default_db_secret")),
+	}
+
+	// Inject cloud API keys if present
+	for _, key := range []string{"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "GROK_API_KEY", "OPENROUTER_API_KEY"} {
+		if val := os.Getenv(key); val != "" {
+			args = append(args, "-e", fmt.Sprintf("%s=%s", key, val))
+		}
+	}
+
+	// Inject local LLM config — allows Ollama or vLLM to be used inside the container
+	if provider := os.Getenv("DEFAULT_LLM_PROVIDER"); provider != "" {
+		args = append(args, "-e", fmt.Sprintf("DEFAULT_LLM_PROVIDER=%s", provider))
+	}
+	if inferenceURL := os.Getenv("LOCAL_INFERENCE_URL"); inferenceURL != "" {
+		// Rewrite localhost → host.docker.internal so the container can reach the host
+		inferenceURL = strings.ReplaceAll(inferenceURL, "localhost", "host.docker.internal")
+		inferenceURL = strings.ReplaceAll(inferenceURL, "127.0.0.1", "host.docker.internal")
+		args = append(args, "-e", fmt.Sprintf("LOCAL_INFERENCE_URL=%s", inferenceURL))
+	}
+	if modelName := os.Getenv("LOCAL_MODEL_NAME"); modelName != "" {
+		args = append(args, "-e", fmt.Sprintf("LOCAL_MODEL_NAME=%s", modelName))
+	}
+
+	// Mount workspace and set working directory
+	args = append(args,
+		"-v", fmt.Sprintf("%s:/app", getEnvOrDefault("PWD", mustGetwd())),
 		"-w", "/app/tendrils/python",
 		d.ImageName,
 		"-m", "src.tendrilloop",
 	)
 
+	cmd := exec.CommandContext(ctx, "docker", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return string(output), fmt.Errorf("docker run failed: %w (output: %s)", err, string(output))
 	}
 
 	return string(output), nil
+}
+
+func getEnvOrDefault(key, fallback string) string {
+	if val := os.Getenv(key); val != "" {
+		return val
+	}
+	return fallback
+}
+
+func mustGetwd() string {
+	wd, _ := os.Getwd()
+	return wd
 }

--- a/tendrils/python/src/llmrouter.py
+++ b/tendrils/python/src/llmrouter.py
@@ -12,7 +12,7 @@ Providers:
   - openai:     GPT models (general purpose)
   - google:     Gemini models (via OpenAI-compatible endpoint)
   - openrouter: Universal gateway (access to 200+ models)
-  - local:      vLLM on local GPU (free, private)
+  - local:      Ollama or vLLM on local GPU (free, private, no API key needed)
 """
 
 import logging
@@ -122,7 +122,9 @@ PROVIDER_CONFIG = {
     },
     "local": {
         "base_url": LOCAL_INFERENCE_URL,
-        "api_key": "not-needed",
+        # Ollama requires a non-empty api_key — "ollama" is the conventional dummy value
+        # ChatOpenAI validator rejects empty strings, so we use this placeholder
+        "api_key": "ollama",
         "type": "openai",
         "models": {
             "fast": LOCAL_MODEL_NAME,


### PR DESCRIPTION
Makes OpenTendril fully usable from a fresh install with a local Ollama LLM — no cloud API key required.