### PR TITLE
fix: update dockerfile and compose for cli-worker model and ollama

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,11 @@ services:
   tendril:
     build: tendrils/python
     user: "${UID:-1000}:${GID:-1000}"
-    ports:
-      - "8080:8080"
+    # Note: No port mapping — the Go Stem (tendril serve) owns :8080.
+    # The Tendril container is an ephemeral worker spawned by the Go Stem via docker run.
+    extra_hosts:
+      # Allow the Tendril container to reach Ollama running on the Docker host
+      - "host.docker.internal:host-gateway"
     env_file:
       - path: .env
         required: false
@@ -45,8 +48,9 @@ services:
       REDIS_PASSWORD: ${REDIS_PASSWORD:-tendril_default_redis_secret}
       SECRET_KEY: ${SECRET_KEY:-tendril_default_jwt_secret}
       DEFAULT_LLM_PROVIDER: ${DEFAULT_LLM_PROVIDER:-grok}
-      LOCAL_INFERENCE_URL: ${LOCAL_INFERENCE_URL:-http://inference:8000/v1}
-      LOCAL_MODEL_NAME: ${LOCAL_MODEL_NAME:-Qwen/Qwen3-8B-AWQ}
+      # For host Ollama: set to http://host.docker.internal:11434/v1 (default for local dev)
+      LOCAL_INFERENCE_URL: ${LOCAL_INFERENCE_URL:-http://host.docker.internal:11434/v1}
+      LOCAL_MODEL_NAME: ${LOCAL_MODEL_NAME:-qwen2.5-coder:7b}
       NANO_MODEL_ENABLED: ${NANO_MODEL_ENABLED:-false}
       TENDRIL_WORKSPACE_ROOT: ${TENDRIL_WORKSPACE_ROOT:-/app}
       SANDBOX_TOKEN: ${SANDBOX_TOKEN:-tendril_default_sandbox_token}

--- a/tendrils/python/Dockerfile
+++ b/tendrils/python/Dockerfile
@@ -11,14 +11,15 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY src/ ./src/
-COPY entrypoint.sh .
 
-RUN chmod +x entrypoint.sh && \
-    adduser --disabled-password --gecos '' tendril && \
+RUN adduser --disabled-password --gecos '' tendril && \
     mkdir -p /app/data/dynamic_skills /app/logs /data /logs /workspace && \
     chown -R tendril:tendril /app /data /logs /workspace && \
     chmod -R 755 /app
 
 USER tendril
 
-ENTRYPOINT ["./entrypoint.sh"]
+# The Go Stem spawns this container as an ephemeral CLI worker:
+#   docker run --rm ... core-tendril:latest -m src.tendrilloop
+# No long-running server; ENTRYPOINT is python for direct -m invocation.
+ENTRYPOINT ["python"]


### PR DESCRIPTION
## What\n- Removes deleted `entrypoint.sh` from Dockerfile (was the old FastAPI server entry, now deleted)\n- Sets `ENTRYPOINT ["python"]` so the Go Stem can run `docker run core-tendril -m src.tendrilloop` directly\n- Removes the `:8080` port mapping from the tendril service (Go Stem now owns that port)\n- Adds `extra_hosts: host.docker.internal:host-gateway` so the container can reach host Ollama\n- Changes `LOCAL_INFERENCE_URL` default to `http://host.docker.internal:11434/v1` and model to `qwen2.5-coder:7b`\n\n## Result\n`docker compose build tendril` now builds successfully and the image is ready to be used as a CLI worker by the Go Stem.