### PR TITLE
fix(mcp): rename tool properties to camelCase (closes #57)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -161,7 +161,7 @@ This ensures zero bleed of `__pycache__`, build artifacts, or secret leakages in
 
 ### D. Cross-pollination (Foreign Substrates)
 While local operation utilizes Shadow Git worktrees from the active repository, OpenTendril is also capable of **Cross-pollination**. 
-If a Tendril is sprouted with a `substrate_url` (a remote Git repository URL), the Orchestrator will:
+If a Tendril is sprouted with a `substrateUrl` (a remote Git repository URL), the Orchestrator will:
 1. Bypass the local repository entirely.
 2. Authenticate and perform a full `git clone` of the remote repository into a temporary sandbox.
 3. Drop the Tendril into this foreign substrate to execute its task (e.g. reviewing code or submitting cross-repo patches).

--- a/cmd/stem/internal/api/mcp.go
+++ b/cmd/stem/internal/api/mcp.go
@@ -168,13 +168,13 @@ func (h *MCPHandler) ProcessMCPMessage(reqBytes []byte) []byte {
 								"type":        "string",
 								"description": "The absolute path to the target repository workspace (the 'substrate'). E.g. /home/user/project",
 							},
-							"substrate_url": map[string]interface{}{
+							"substrateUrl": map[string]interface{}{
 								"type":        "string",
 								"description": "Optional remote repository URL to clone and operate on dynamically. E.g. https://github.com/opentendril/core.git",
 							},
-							"substrate_branch": map[string]interface{}{
+							"substrateBranch": map[string]interface{}{
 								"type":        "string",
-								"description": "Optional branch name to clone if substrate_url is provided.",
+								"description": "Optional branch name to clone if substrateUrl is provided.",
 							},
 						},
 						"required": []string{"transcript", "substrate"},
@@ -258,8 +258,8 @@ func (h *MCPHandler) ProcessMCPMessage(reqBytes []byte) []byte {
 			return h.formatError(req.ID, -32602, "Invalid arguments", "The 'transcript' and 'substrate' parameters are required.")
 		}
 
-		substrateURL, _ := params.Arguments["substrate_url"].(string)
-		substrateBranch, _ := params.Arguments["substrate_branch"].(string)
+		substrateURL, _ := params.Arguments["substrateUrl"].(string)
+		substrateBranch, _ := params.Arguments["substrateBranch"].(string)
 
 		log.Printf("[MCP] Delegating transcript to Tendril: %s (Substrate: %s, URL: %s)", transcript, substrate, substrateURL)
 		orch := &orchestrator.DockerOrchestrator{


### PR DESCRIPTION
## Summary
Standardizes all MCP tool property names from Python's snake_case to camelCase, decoupling the public API surface from Python conventions.

## Changes
- `substrate_url` → `substrateUrl` (schema + argument parsing in `mcp.go`)
- `substrate_branch` → `substrateBranch` (schema + argument parsing in `mcp.go`)
- `ARCHITECTURE.md` doc reference updated

## Verification
- `go build ./cmd/stem/...` ✅
- `go test ./cmd/stem/...` ✅ (orchestrator tests pass)

## Breaking change
Pre-1.0 breaking change. Callers must update to camelCase property names.

Closes #57