### PR TITLE
docs: Add TENDRIL-GUIDE.md material and architecture guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ To understand OpenTendril, you must understand its anatomy:
 *   **The Sprout (Ephemeral Docker Container):** OpenTendril does not run continuous, stateful background agents. For every Transcript, a new isolated *Sprout* (container) instantly boots, executes, and is destroyed. Zero idle cost. Zero state corruption.
 *   **The Immune System (Security & Tests):** Security is a biological reflex. *Hormonal Triggers* (pre-execution bash scripts) instantly abort anomalous behavior, while an automated test suite (Adaptive Immune System) runs in sterile containers to ensure the organism rejects harmful code mutations.
 
-> 📖 **Read the full philosophy:** Dive into the [Synthetic Biological Taxonomy](SYNTHETIC-TAXONOMY.md) to explore the complete design system and architecture.
+> 📖 **Read the full philosophy:** Dive into the [Synthetic Biological Taxonomy](SYNTHETIC-TAXONOMY.md) to explore the complete design system.
+> 🛠️ **Read the engineering guide:** Check the [Material & Architecture Guide](TENDRIL-GUIDE.md) to understand how these concepts are physically built (languages, tools, and protocols).
 
 ### What does this actually mean for developers?
 In standard IT speak: **OpenTendril is a headless, local-first AI coding framework.** It runs entirely on your machine, talks to any frontend (Claude Desktop, VS Code, Cursor), and executes code safely within ephemeral Docker sandboxes. 

--- a/SYNTHETIC-TAXONOMY.md
+++ b/SYNTHETIC-TAXONOMY.md
@@ -4,6 +4,7 @@ OpenTendril replaces traditional, generic IT terminology with biological and bot
 
 This document serves as the formal **Taxonomy and Systematics** of this synthetic organism. It educates contributors (and non-biologists!) on exactly how these organic concepts map directly to modern LLM engineering paradigms, classifying the nomenclature and explaining *why* we built the system this way.
 
+> 🛠️ **Looking for how to build?** This document explains the *what* and *why*. For practical engineering decisions (which language to use where, how to build an executor), read the [Material & Architecture Guide](TENDRIL-GUIDE.md).
 ---
 
 ## 1. The Philosophy: Escaping Determinism

--- a/TENDRIL-GUIDE.md
+++ b/TENDRIL-GUIDE.md
@@ -1,0 +1,91 @@
+# OpenTendril: Material & Architecture Guide
+
+This document is the practical companion to the [`SYNTHETIC-TAXONOMY.md`](SYNTHETIC-TAXONOMY.md). While the taxonomy defines the *biological concepts* of OpenTendril, this guide defines the *engineering materials*. It explains which languages and technologies are used for each layer, and provides a step-by-step guide on how to construct a new Tendril executor.
+
+## The Core Principle
+
+> **The language choice should be made by the process, not the developer.**
+
+Each layer of OpenTendril is constructed from the material that best serves its purpose. No single language dominates the framework. If a task requires manipulating a Python Abstract Syntax Tree, the executor must be Python. If a task requires high-concurrency file orchestration via MCP, the executor should be TypeScript.
+
+---
+
+## Material Mapping Matrix
+
+| Layer | Material | Rationale |
+|---|---|---|
+| **Stem (Orchestrator)** | **Go** | Single binary, zero-dependency deployment. Goroutines for concurrent Tendril dispatch. Extremely fast startup. |
+| **Hormonal Triggers** | **Shell → Go → OPA** | Progressive complexity. Simple gates use Bash. Complex auth/RBAC is compiled into Go. Future declarative policy will use Open Policy Agent (Rego). |
+| **Genotypes / Plasmids / Sequences** | **YAML + Markdown** | Configuration and prompt data are not code. They must be human-readable, editable without an IDE, and git-diffable. |
+| **Sprout** | **OCI / Docker** | The isolation mechanism. The Sprout itself is language-agnostic; the image *inside* the Sprout changes per task. |
+| **Default Executor** | **TypeScript / Node** | Used when the Substrate language is unknown or mixed. MCP SDK is TypeScript-first. Excellent async I/O. Tiny Docker image (`node:alpine`). Type-safe JSON boundaries. |
+| **Python Executor** | **Python** | Only instantiated when the Substrate *is* a Python project. Essential for `pytest`, `pip`, Python AST manipulation, and tree-sitter bindings. |
+| **Go Executor** | **Go** | Only instantiated when the Substrate *is* a Go project. Used for `go test`, `go build`, and understanding Go module structure. |
+| **AST / Repo Map** | **Go + Tree-sitter** | Pre-flight analysis that runs inside the Go Stem binary *before* a Tendril is spawned. |
+| **Memory / RAG** | **MCP Sidecar** | Persistent memory is handled by external MCP servers (e.g., `mcp-memory-service` or `pgvector`), not bespoke internal code. |
+
+---
+
+## The Tendril JSON API Contract
+
+Every Tendril executor—regardless of language—must implement a strict universal protocol. The Tendril does **not** contain LLM reasoning loops. It is a dumb worker that receives a fully resolved instruction and executes it.
+
+**The Protocol:**
+1. Read exactly one line of JSON from `stdin`.
+2. Parse the instruction and execute the appropriate local tools.
+3. Write exactly one line of JSON to `stdout`.
+4. Exit.
+
+### Input Schema (`stdin`)
+```json
+{
+  "transcript": "Read the file README.md and return its contents",
+  "genotype": "python-dev",
+  "workspace": "/app"
+}
+```
+
+### Output Schema (`stdout`)
+```json
+{
+  "status": "success",
+  "output": "# OpenTendril\n..."
+}
+```
+
+### Error Schema (`stdout`)
+```json
+{
+  "status": "error",
+  "output": "File not found: README.md"
+}
+```
+
+---
+
+## How to Build a New Tendril Executor
+
+When introducing support for a new Substrate ecosystem (e.g., Rust, Java, Ruby), you must construct a new Tendril executor. Follow these steps:
+
+### 1. Language Decision Checklist
+*   **Is this a general-purpose task?** (e.g., "Review this PR", "Edit this Markdown file"). Use the **Default Executor (TypeScript)**. Do not build a new executor.
+*   **Does the task require native ecosystem tools?** (e.g., `cargo test`, `maven build`). You must build a language-specific executor (e.g., a Rust executor, a Java executor).
+
+### 2. Define the Genotype
+Create the identity for this Tendril in `.tendril/genotypes/<name>.md`. Use progressive disclosure:
+*   **Frontmatter:** A lightweight YAML block containing the name and a short description (loaded by the Mycorrhizal LLM for selection).
+*   **Body:** The full Markdown system prompt detailing the constraints, persona, and default Plasmids (injected into the context when instantiated).
+
+### 3. Create the Executor Scaffold
+In the `tendrils/<language>/` directory, create:
+1.  **Dockerfile:** Use the smallest possible base image (e.g., Alpine). Do NOT install LLM dependencies (no LangChain, no SDKs). Install only the language runtime and necessary ecosystem tools (e.g., test runners, linters).
+2.  **Protocol Binding:** Implement the JSON `stdin`/`stdout` loop.
+3.  **Tool Implementations:** Write the wrappers for file I/O, Git operations, and language-specific commands. Keep them as thin functions.
+
+*Note: Reference `tendrils/typescript/` for the gold standard implementation of an executor.*
+
+### 4. Write the CI Test Stub
+Ensure your executor can be verified without an LLM. Write a local unit test in the executor's language that:
+1. Pipes a mock JSON transcript to `stdin`.
+2. Asserts that the executor performs the action.
+3. Asserts that valid JSON is emitted on `stdout`.


### PR DESCRIPTION
## Summary
Adds `TENDRIL-GUIDE.md` as a practical companion to `SYNTHETIC-TAXONOMY.md`.

While the taxonomy defines the *biological concepts*, this guide defines the *engineering materials*, explaining which languages are used for each layer of the architecture, and provides a step-by-step template for how to construct new Tendril executors.

Also updates `README.md` and `SYNTHETIC-TAXONOMY.md` to point to the new guide.